### PR TITLE
2 irregular English plurals

### DIFF
--- a/inflector/languages/english.py
+++ b/inflector/languages/english.py
@@ -39,14 +39,15 @@ class English(Base):
             ['(?i)$' , 's']
         ]
         
-        uncountable_words = ['equipment', 'information', 'rice', 'money', 'species', 'series', 'fish', 'sheep']
+        uncountable_words = ['equipment', 'information', 'rice', 'money', 'species', 'series', 'fish', 'sheep', 'deer']
         
         irregular_words = {
             'person' : 'people',
             'man' : 'men',
             'child' : 'children',
             'sex' : 'sexes',
-            'move' : 'moves'
+            'move' : 'moves',
+            'staff' : 'staves',
         }
         
         lower_cased_word = word.lower();


### PR DESCRIPTION
These weren't covered by the general rules so I added them as special cases. I could see an argument for "anything ending in `-ff` pluralizes as `-ves`" but I wasn't confident enough to make that change.

Thanks for getting this into pypi!
