### PR TITLE
Remove unnecessary data_files from setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -20,9 +20,6 @@ setup(name='Inflector',
       keywords="inflector text language english",
       packages=["inflector"],
       package_dir={'inflector': 'inflector'},
-      data_files=[
-          ("", ['README.md', 'LICENSE', 'VERSION'])
-      ],
       include_package_data=True,
       zip_safe=False,
       test_suite='tests'


### PR DESCRIPTION
This should resolve https://github.com/ixmatus/inflector/issues/4.

It's not necessary to include README.md, LICENSE, and VERSION in an installation, as all the info contained in them is already contained in the package metadata that gets stored in the dist-info or egg-info directory.
