### PR TITLE
Fixes backwards compatibility issues with Python 2

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,5 @@
 import os
+from io import open
 from setuptools import setup
 
 here = os.path.abspath(os.path.dirname(__file__))


### PR DESCRIPTION
In Python 2, the open() function takes no encoding argument.
Use the open function from the io module in python 2.