### PR TITLE
Hotfix for re.error in Python 3.11

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,35 @@
+name: Test
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+jobs:
+  test:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+        python-version: [ '3.11', '3.10', '3.9', '3.8', '3.7' ]
+      fail-fast: false
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
+      - run: python -m unittest
+  test_legacy:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-20.04, windows-latest]
+        python-version: [ '3.6', '3.5', '2.7' ]
+      fail-fast: false
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
+      - run: python -m unittest

--- a/inflector/languages/english.py
+++ b/inflector/languages/english.py
@@ -20,7 +20,7 @@ class English(Base):
         
         rules = [
             ['(?i)(quiz)$' , '\\1zes'],
-            ['^(?i)(ox)$' , '\\1en'],
+            ['(?i)^(ox)$' , '\\1en'],
             ['(?i)([m|l])ouse$' , '\\1ice'],
             ['(?i)(matr|vert|ind)ix|ex$' , '\\1ices'],
             ['(?i)(x|ch|ss|sh)$' , '\\1es'],


### PR DESCRIPTION
This is to support Python 3.11. See: #12 

At same time, implemented minimum GitHub Actions for guarantee safeness of pull request.