### PR TITLE
Python 3.12 support

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest]
-        python-version: [ '3.11', '3.10', '3.9', '3.8', '3.7' ]
+        python-version: [ '3.12', '3.11', '3.10', '3.9', '3.8' ]
       fail-fast: false
     steps:
       - uses: actions/checkout@v3
@@ -25,7 +25,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-20.04, windows-latest]
-        python-version: [ '3.6', '3.5', '2.7' ]
+        python-version: [ '3.7', '3.6', '3.5', '2.7' ]
       fail-fast: false
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,7 +25,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-20.04, windows-latest]
-        python-version: [ '3.7', '3.6', '3.5', '2.7' ]
+        python-version: [ '3.7', '3.6', '3.5' ]
       fail-fast: false
     steps:
       - uses: actions/checkout@v3

--- a/inflector/__init__.py
+++ b/inflector/__init__.py
@@ -4,7 +4,6 @@
 # See the end of this file for the free software, open source license (BSD-style).
 
 from inflector.languages.english import English
-from inflector.languages.spanish import Spanish
 
 
 class Inflector(object):

--- a/inflector/languages/base.py
+++ b/inflector/languages/base.py
@@ -45,9 +45,9 @@ class Base(object):
         "underscored_word".
         This can be really useful for creating friendly URLs.'''
 
-        return  re.sub('[^A-Z^a-z^0-9^\/]+', '_', \
-                re.sub('([a-z\d])([A-Z])', '\\1_\\2', \
-                re.sub('([A-Z]+)([A-Z][a-z])', '\\1_\\2', re.sub('::', '/', word)))).lower()
+        return  re.sub(r'[^A-Z^a-z^0-9^\/]+', '_', \
+                re.sub(r'([a-z\d])([A-Z])', '\\1_\\2', \
+                re.sub(r'([A-Z]+)([A-Z][a-z])', '\\1_\\2', re.sub(r'::', '/', word)))).lower()
 
     def humanize(self, word, uppercase=''):
         '''Returns a human-readable string from word

--- a/inflector/languages/english.py
+++ b/inflector/languages/english.py
@@ -53,7 +53,7 @@ class English(Base):
             'goose' : 'geese',
         }
         
-        lower_cased_word = word.lower();
+        lower_cased_word = word.lower()
         
         for uncountable_word in uncountable_words:
             if lower_cased_word[-1*len(uncountable_word):] == uncountable_word :
@@ -69,7 +69,7 @@ class English(Base):
             if match :
                 groups = match.groups()
                 for k in range(0,len(groups)) :
-                    if groups[k] == None :
+                    if groups[k] is None :
                         rules[rule][1] = rules[rule][1].replace('\\'+str(k+1), '')
                         
                 return re.sub(rules[rule][0], rules[rule][1], word)
@@ -105,9 +105,9 @@ class English(Base):
             ['(?i)([ti])a$' , '\\1um'],
             ['(?i)(n)ews$' , '\\1ews'],
             ['(?i)s$' , ''],
-        ];
+        ]
     
-        uncountable_words = ['equipment', 'information', 'rice', 'money', 'species', 'series', 'fish', 'sheep','sms'];
+        uncountable_words = ['equipment', 'information', 'rice', 'money', 'species', 'series', 'fish', 'sheep','sms']
     
         irregular_words = {
             'people' : 'person',
@@ -117,7 +117,7 @@ class English(Base):
             'moves' : 'move'
         }
     
-        lower_cased_word = word.lower();
+        lower_cased_word = word.lower()
     
         for uncountable_word in uncountable_words:
             if lower_cased_word[-1*len(uncountable_word):] == uncountable_word :
@@ -134,7 +134,7 @@ class English(Base):
             if match :
                 groups = match.groups()
                 for k in range(0,len(groups)) :
-                    if groups[k] == None :
+                    if groups[k] is None :
                         rules[rule][1] = rules[rule][1].replace('\\'+str(k+1), '')
                         
                 return re.sub(rules[rule][0], rules[rule][1], word)

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -6,7 +6,7 @@
 # bermi a-t bermilabs - com
 #
 import unittest
-from inflector import Inflector, English, Spanish
+from inflector import Inflector, English
 
 class EnglishInflectorTestCase(unittest.TestCase):
     singular_to_plural = {


### PR DESCRIPTION
- Add support to python 3.12
- Fix code warnings

```
inflector/languages/base.py:48: SyntaxWarning: invalid escape sequence '\/'
  return  re.sub('[^A-Z^a-z^0-9^\/]+', '_', \
inflector/languages/base.py:49: SyntaxWarning: invalid escape sequence '\d'
  re.sub('([a-z\d])([A-Z])', '\\1_\\2', \
```